### PR TITLE
Include showdown-prettify in depedencies for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "bootstrap-css-only": "^3.3.6",
     "angular-bootstrap": "^1.3.1",
     "ace-builds": "^1.2.3",
-    "components-font-awesome": "^4.6.3"
+    "components-font-awesome": "^4.6.3",
+    "showdown-prettify": "^1.3.0"
   },
   "overrides": {
     "ace-builds": {


### PR DESCRIPTION
When cloning the repository and running `grunt` the build fails because the dependency is missing